### PR TITLE
Security fix for Cross-Site Scripting in thirtybees

### DIFF
--- a/admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/import/helpers/form/form.tpl
@@ -447,7 +447,7 @@
 			var index = data.index,	file = data.files[index];
 
 			if (file.error) {
-				$('#file-errors').append('<strong>'+file.name+'</strong> ('+humanizeSize(file.size)+') : '+file.error).show();
+				$('#file-errors').append('<strong>'+file.name.replace(/<|>/g, (char) => char == '<' ? '&lt;' : '&gt;')+'</strong> ('+humanizeSize(file.size)+') : '+file.error).show();
 				$(data.context).find('button').trigger('click');
 			}
 		});

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -682,6 +682,7 @@ class AdminImportControllerCore extends AdminController
     public function ajaxProcessuploadCsv()
     {
         $filenamePrefix = date('YmdHis').'-';
+        $filename = preg_replace('/[^A-Za-z0-9._\-]/', '', $_FILES['file']['name']);
 
         if (isset($_FILES['file']) && !empty($_FILES['file']['error'])) {
             switch ($_FILES['file']['error']) {
@@ -698,15 +699,15 @@ class AdminImportControllerCore extends AdminController
                     $_FILES['file']['error'] = $this->l('No file was uploaded.');
                     break;
             }
-        } elseif (!preg_match('#([^\.]*?)\.(csv|xls[xt]?|o[dt]s)$#is', $_FILES['file']['name'])) {
+        } elseif (!preg_match('#([^\.]*?)\.(csv|xls[xt]?|o[dt]s)$#is', $filename)) {
             $_FILES['file']['error'] = $this->l('The extension of your file should be .csv.');
         } elseif (!@filemtime($_FILES['file']['tmp_name']) ||
-            !@move_uploaded_file($_FILES['file']['tmp_name'], static::getPath().$filenamePrefix.str_replace("\0", '', $_FILES['file']['name']))
+            !@move_uploaded_file($_FILES['file']['tmp_name'], static::getPath().$filenamePrefix.str_replace("\0", '', $filename))
         ) {
             $_FILES['file']['error'] = $this->l('An error occurred while uploading / copying the file.');
         } else {
-            @chmod(static::getPath().$filenamePrefix.$_FILES['file']['name'], 0664);
-            $_FILES['file']['filename'] = $filenamePrefix.str_replace('\0', '', $_FILES['file']['name']);
+            @chmod(static::getPath().$filenamePrefix.$filename, 0664);
+            $_FILES['file']['filename'] = $filenamePrefix.str_replace('\0', '', $filename);
         }
 
         $this->ajaxDie(json_encode($_FILES));


### PR DESCRIPTION
### 📊 Metadata *

`Thirtybees` is matured e-commerce solution which once started as a fork of PrestaShop 1.6.1.11 and is still compatible with (almost) all PS 1.6 modules. Its focus is on stability, correctness and reliability of the rich feature set, to allow merchants to focus on growing their business. this package is vulnerable to `Stored Cross-Site Scripting (XSS)`.

#### Bounty URL: https://www.huntr.dev/bounties/1-other-thirtybees%2Fthirtybees

### ⚙️ Description *

Cross-Site Scripting (XSS) attacks are a type of injection, in which malicious scripts are injected into otherwise benign and trusted websites. XSS attacks occur when an attacker uses a web application to send malicious code, generally in the form of a browser side script, to a different end user. Flaws that allow these attacks to succeed are quite widespread and occur anywhere a web application uses input from a user within the output it generates without validating or encoding it. In `thirtybees` the `CSV import` functionality does not properly validate importing filename which allows `Stored XSS` by naming the file as any XSS payload.

### 💻 Technical Description *

Fix is implemented by removing malicious characters in the imported filename before uploading it.

### 🐛 Proof of Concept (PoC) *

[gdrive link](https://drive.google.com/drive/folders/1aozrNN4u0tXIPFTHbefQPOZHKbbHLRGY)

### 🔥 Proof of Fix (PoF) *

There is also a `Reflected XSS` when trying to upload files with extension other than `.csv`. This is also fixed by validating filename before rendering it.

1 ![pof1](https://raw.githubusercontent.com/arjunshibu/files/main/thirtybees-fix/thirtybees-pof1.png)
2 ![pof2](https://raw.githubusercontent.com/arjunshibu/files/main/thirtybees-fix/thirtybees-pof2.png)
3 ![pof3](https://raw.githubusercontent.com/arjunshibu/files/main/thirtybees-fix/thirtybees-pof3.png)

### 👍 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
